### PR TITLE
Improve performance of electric field calculation

### DIFF
--- a/examples/calc_vols.py
+++ b/examples/calc_vols.py
@@ -7,7 +7,7 @@ import os
 
 df = pd.DataFrame()
 
-for mpath in glob.glob('/PATH/TO/CUBE/FILES/*.cube'):
+for mpath in glob.glob('*.cube'):
   el = mpath.split('/')
   molecule = el[len(el)-2]
   print(molecule)

--- a/streusel/math_functions.py
+++ b/streusel/math_functions.py
@@ -18,10 +18,10 @@ Args:
 	gx/y/z : fields in x y and z directions 2D array
 Returns:
 	grad_mag : gradient of fields at each point"""
-	grad_mag = gx
-	for i in range(gx.shape[0]):
-		for j in range(gy.shape[1]):
-			for k in range(gz.shape[2]):
-				grad_mag[i,j,k] = np.sqrt(gx[i,j,k]**2+gy[i,j,k]**2+gz[i,j,k]**2)
 
-	return grad_mag
+        out = np.square(gx)
+        out += np.square(gy)
+        out += np.square(gz)
+        
+        return np.sqrt(out, out=out)
+


### PR DESCRIPTION
Significant decrease in time it takes to calculate the electric field
magnitude by moving away from nested for loops and taking advantage
of numpy.

Co-authored-by: Lukas Turcani <lukasturcani@mailbox.org>